### PR TITLE
Background image

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -4,7 +4,7 @@
 
 .games-main {
   height: 100%;
-  background-image: url("http://wallpaper.zone/img/282768.jpg");
+  background-image: url("/images/backgrounds/mario_scroll.gif");
   background-repeat: no-repeat;
   background-size: 100% 100%;
 }


### PR DESCRIPTION
Applies a new background image to the landing page

Issues
- The image is more grainy than I expected when it is stretched to fill a screen
- the gif may make the page take longer to load

Here's a link to something that looks a lot like the original image we used if you want to switch it back: http://hugoware.net/resource/images/misc/game-background.jpg
